### PR TITLE
fix(upload): bring back parts information to upload /complete API call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ osx_image: xcode9.4
 branches:
   only:
     - master
+    - develop
 env:
   global:
   - LC_CTYPE=en_US.UTF-8

--- a/FilestackSDK/Models/MultipartUpload.swift
+++ b/FilestackSDK/Models/MultipartUpload.swift
@@ -213,6 +213,7 @@ private extension MultipartUpload {
                                   uri: uri,
                                   region: region,
                                   uploadID: uploadID,
+                                  partsAndEtags: partsAndEtags,
                                   useIntelligentIngestion: shouldUseIntelligentIngestion,
                                   retriesLeft: self.maxRetries)
       }
@@ -318,6 +319,7 @@ private extension MultipartUpload {
                             uri: String,
                             region: String,
                             uploadID: String,
+                            partsAndEtags: [Int: String],
                             useIntelligentIngestion: Bool,
                             retriesLeft: Int) {
     let completeOperation = MultipartUploadCompleteOperation(apiKey: apiKey,
@@ -328,6 +330,7 @@ private extension MultipartUpload {
                                                              region: region,
                                                              uploadID: uploadID,
                                                              storeOptions: storeOptions,
+                                                             partsAndEtags: partsAndEtags,
                                                              useIntelligentIngestion: useIntelligentIngestion)
     
     weak var weakCompleteOperation = completeOperation
@@ -350,6 +353,7 @@ private extension MultipartUpload {
                                       uri: uri,
                                       region: region,
                                       uploadID: uploadID,
+                                      partsAndEtags: partsAndEtags,
                                       useIntelligentIngestion: useIntelligentIngestion,
                                       retriesLeft: retriesLeft - 1)
           }

--- a/FilestackSDK/Operations/MultipartUploadCompleteOperation.swift
+++ b/FilestackSDK/Operations/MultipartUploadCompleteOperation.swift
@@ -19,6 +19,7 @@ class MultipartUploadCompleteOperation: BaseOperation {
   let region: String
   let uploadID: String
   let storeOptions: StorageOptions
+  let parts: String
   let useIntelligentIngestion: Bool
   
   var response = NetworkJSONResponse(with: MultipartUploadError.aborted)
@@ -31,6 +32,7 @@ class MultipartUploadCompleteOperation: BaseOperation {
                 region: String,
                 uploadID: String,
                 storeOptions: StorageOptions,
+                partsAndEtags: [Int: String],
                 useIntelligentIngestion: Bool) {
     self.apiKey = apiKey
     self.fileName = fileName
@@ -40,6 +42,7 @@ class MultipartUploadCompleteOperation: BaseOperation {
     self.region = region
     self.uploadID = uploadID
     self.storeOptions = storeOptions
+    self.parts = (partsAndEtags.map { "\($0.key):\($0.value)" }).joined(separator:";")
     self.useIntelligentIngestion = useIntelligentIngestion
     
     super.init()
@@ -81,7 +84,7 @@ private extension MultipartUploadCompleteOperation {
     if self.useIntelligentIngestion {
       form.append("true", withName: "multipart")
     } else {
-      form.append("", withName: "parts")
+      form.append(parts, withName: "parts")
     }
   }
 }


### PR DESCRIPTION
Bringing back parts information to /complete upload call in order to fix 400 errors from API.