### PR TITLE
#19 : UUID is returned instead of actual filename while uploading from local source

### DIFF
--- a/FilestackSDK/Internal/Uploaders/MultipartUpload.swift
+++ b/FilestackSDK/Internal/Uploaders/MultipartUpload.swift
@@ -145,7 +145,7 @@ private extension MultipartUpload {
     func doUploadFile() {
         currentStatus = .inProgress
 
-        let fileName = options.storeOptions.filename ?? UUID().uuidString
+        let fileName = options.storeOptions.filename ?? uploadable.filename ?? UUID().uuidString
         let mimeType = options.storeOptions.mimeType ?? uploadable.mimeType ?? "text/plain"
 
         guard let fileSize = uploadable.size, !fileName.isEmpty else {

--- a/FilestackSDK/Public/Extensions/Data+Uploadable.swift
+++ b/FilestackSDK/Public/Extensions/Data+Uploadable.swift
@@ -9,6 +9,10 @@
 import Foundation
 
 extension Data: Uploadable {
+    public var filename: String? {
+        return nil
+    }
+
     public var size: UInt64? {
         return UInt64(count)
     }

--- a/FilestackSDK/Public/Extensions/URL+Uploadable.swift
+++ b/FilestackSDK/Public/Extensions/URL+Uploadable.swift
@@ -10,6 +10,10 @@ import Foundation
 import MobileCoreServices
 
 extension URL: Uploadable {
+    public var filename: String? {
+        return lastPathComponent
+    }
+
     public var size: UInt64? {
         guard let attributtes = try? FileManager.default.attributesOfItem(atPath: relativePath) else { return nil }
 

--- a/FilestackSDK/Public/Protocols/Uploadable.swift
+++ b/FilestackSDK/Public/Protocols/Uploadable.swift
@@ -10,6 +10,8 @@ import Foundation
 
 /// The protocol any uploadables must conform to.
 public protocol Uploadable {
+    /// The fileName of this uploadable, or `nil` if unavailable.
+    var filename: String? { get }
     /// The size of this uploadable in bytes, or `nil` if unavailable.
     var size: UInt64? { get }
     /// The MIME type of this uploadable, or `nil` if unavailable.


### PR DESCRIPTION
#19 : UUID is returned instead of actual filename while uploading from local source.

The issue is introduced due to refactor to migrate the localURLS to Uploadable.

let fileName = options.storeOptions.filename ?? UUID().uuidString
Before
let fileName = storeOptions.filename ?? localURL.lastPathComponent