### PR TITLE
#21 : Missing filename with extension in store options path cause rendering issue for s3.

### DIFF
--- a/FilestackSDK/Internal/Extensions/StorageOptions+MultipartFormData.swift
+++ b/FilestackSDK/Internal/Extensions/StorageOptions+MultipartFormData.swift
@@ -14,12 +14,19 @@ extension StorageOptions {
         form.append(location.description, withName: "store_location")
         form.append(region, withName: "store_region")
         form.append(container, withName: "store_container")
-        form.append(path, withName: "store_path")
+        form.append(completePath, withName: "store_path")
         form.append(access?.description, withName: "store_access")
 
         if let workflows = workflows {
             let joinedWorkflows = "[\((workflows.map { "\"\($0)\"" }).joined(separator: ","))]"
             form.append(joinedWorkflows, withName: "workflows")
         }
+    }
+    
+    internal var completePath: String? {
+        guard let path = path, let fileName = filename else {
+            return nil
+        }
+        return "\(path)_\(fileName)"
     }
 }

--- a/FilestackSDK/Internal/Uploaders/MultipartUpload.swift
+++ b/FilestackSDK/Internal/Uploaders/MultipartUpload.swift
@@ -152,6 +152,7 @@ private extension MultipartUpload {
             fail(with: MultipartUploadError.invalidFile)
             return
         }
+        options.updateStoreOptions(fileName: fileName, mimeType: mimeType)
 
         let startOperation = MultipartUploadStartOperation(apiKey: apiKey,
                                                            fileName: fileName,

--- a/FilestackSDK/Public/Models/UploadOptions.swift
+++ b/FilestackSDK/Public/Models/UploadOptions.swift
@@ -50,6 +50,13 @@ import Foundation
     }()
 }
 
+extension UploadOptions {
+    internal func updateStoreOptions(fileName: String, mimeType: String) {
+        storeOptions.filename = fileName
+        storeOptions.mimeType = mimeType
+    }
+}
+
 // MARK: - CustomStringConvertible
 
 extension UploadOptions {


### PR DESCRIPTION
#21 : Missing filename with extension in store options path cause rendering issue for s3.

Append filename when creating form data, Also provide option to update the filename when changed. See issue #19

Issue : https://github.com/filestack/filestack-swift/issues/21